### PR TITLE
Fix httpx dependency version to be compatible with langchain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ packages = [{ include = "upstash_vector" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-httpx = ">=0.24.1,<0.26.0"
+httpx = "^0.24.1"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ packages = [{ include = "upstash_vector" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-httpx = "^0.25.0"
+httpx = ">=0.24.1,<0.26.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.8.0"


### PR DESCRIPTION
```
> poetry add upstash_vector --optional
Using version ^0.2.0 for upstash-vector

Updating dependencies
Resolving dependencies... (0.2s)

Because upstash-vector (0.2.0) depends on httpx (>=0.25.0,<0.26.0)
 and no versions of upstash-vector match >0.2.0,<0.3.0, upstash-vector (>=0.2.0,<0.3.0) requires httpx (>=0.25.0,<0.26.0).
So, because langchain-community depends on both httpx (^0.24.1) and upstash-vector (^0.2.0), version solving failed.
```