### PR TITLE
Allow a more broad range for httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ packages = [{ include = "upstash_vector" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-httpx = "^0.24.1"
+httpx = ">=0.24.0, <0.28"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.8.0"


### PR DESCRIPTION
We needed to set the lower bound to 0.24 for langchain integration, but we need to allow users to use more recent versions in case they are not dependenging on older versions of httpx.