### PR TITLE
Fix: Handle None Namespace Case Properly

### DIFF
--- a/tests/core/test_upsert.py
+++ b/tests/core/test_upsert.py
@@ -637,6 +637,24 @@ def test_upsert_data(embedding_index: Index, ns: str):
     assert res[1].data == v2_data
 
 
+def test_upsert_to_none_namespace(embedding_index: Index):
+    v_id = "none_namespace_vector_id"
+    v1_data = "Hello-World"
+
+    embedding_index.upsert(
+        vectors=[
+            Data(id=v_id, data=v1_data),
+        ],
+        namespace=None,
+    )
+
+    # test if the data is indeed inserted to default namespace with namespace=None config
+    res = embedding_index.fetch(ids=[v_id], include_data=True, namespace="")
+
+    assert res[0] is not None
+    assert res[0].id == v_id
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("ns", NAMESPACES)
 async def test_upsert_data_async(async_embedding_index: AsyncIndex, ns: str):

--- a/tests/core/test_upsert.py
+++ b/tests/core/test_upsert.py
@@ -645,7 +645,7 @@ def test_upsert_to_none_namespace(embedding_index: Index):
         vectors=[
             Data(id=v_id, data=v1_data),
         ],
-        namespace=None,
+        namespace=None,  # type: ignore[arg-type]
     )
 
     # test if the data is indeed inserted to default namespace with namespace=None config

--- a/upstash_vector/core/index_operations.py
+++ b/upstash_vector/core/index_operations.py
@@ -52,7 +52,7 @@ RESUMABLE_QUERY_END_PATH = "/resumable-query-end"
 
 
 def _path_for(namespace: str, path: str) -> str:
-    if namespace == DEFAULT_NAMESPACE:
+    if namespace == DEFAULT_NAMESPACE or not namespace:
         return path
 
     return f"{path}/{namespace}"


### PR DESCRIPTION
Currently, the below snippet upserts a vector to namespace `None`. We're now handling it to upsert to the default namespace.

```python
index = Index.from_env()

vec = [1] * 1536

res = index.upsert(vectors=[{"id": "1", "vector": vec}], namespace=None)
```