### PR TITLE
Increase http read/write timeout

### DIFF
--- a/upstash_vector/client.py
+++ b/upstash_vector/client.py
@@ -35,7 +35,7 @@ class Index(IndexOperations):
         self._url = url
         self._client = httpx.Client(
             timeout=httpx.Timeout(
-                timeout=120.0,
+                timeout=600.0,
                 connect=10.0,
             )
         )
@@ -97,7 +97,7 @@ class AsyncIndex(AsyncIndexOperations):
         self._headers = generate_headers(token)
         self._client = httpx.AsyncClient(
             timeout=httpx.Timeout(
-                timeout=120.0,
+                timeout=600.0,
                 connect=10.0,
             )
         )


### PR DESCRIPTION
We saw that during upsert of large batches, index might fail to answer in 2 minutes if it is performing indexing in the background.

Therefore, I am bumping the http timeout to 10 minutes until we make it faster on the backend.