### PR TITLE
Add support for new info endpoint fields

### DIFF
--- a/tests/core/test_info.py
+++ b/tests/core/test_info.py
@@ -39,6 +39,34 @@ def test_info(index: Index):
     assert_eventually(assertion)
 
 
+def test_info_dense_index(index: Index):
+    info = index.info()
+
+    assert info.dense_index is not None
+    assert info.dense_index.dimension == 2
+    assert info.dense_index.similarity_function == "COSINE"
+    assert info.dense_index.embedding_model == ""
+
+
+def test_info_sparse_index(sparse_index: Index):
+    info = sparse_index.info()
+
+    assert info.sparse_index is not None
+    assert info.sparse_index.embedding_model == ""
+
+
+def test_info_hybrid_index(hybrid_index: Index):
+    info = hybrid_index.info()
+
+    assert info.dense_index is not None
+    assert info.dense_index.dimension == 2
+    assert info.dense_index.similarity_function == "COSINE"
+    assert info.dense_index.embedding_model == ""
+
+    assert info.sparse_index is not None
+    assert info.sparse_index.embedding_model == ""
+
+
 @pytest.mark.asyncio
 async def test_info_async(async_index: AsyncIndex):
     for ns in NAMESPACES:
@@ -67,3 +95,34 @@ async def test_info_async(async_index: AsyncIndex):
             assert i.namespaces[ns].vector_count == 1
 
     await assert_eventually_async(assertion)
+
+
+@pytest.mark.asyncio
+async def test_info_dense_index_async(async_index: AsyncIndex):
+    info = await async_index.info()
+
+    assert info.dense_index is not None
+    assert info.dense_index.dimension == 2
+    assert info.dense_index.similarity_function == "COSINE"
+    assert info.dense_index.embedding_model == ""
+
+
+@pytest.mark.asyncio
+async def test_info_sparse_index_async(async_sparse_index: AsyncIndex):
+    info = await async_sparse_index.info()
+
+    assert info.sparse_index is not None
+    assert info.sparse_index.embedding_model == ""
+
+
+@pytest.mark.asyncio
+async def test_info_hybrid_index_async(async_hybrid_index: AsyncIndex):
+    info = await async_hybrid_index.info()
+
+    assert info.dense_index is not None
+    assert info.dense_index.dimension == 2
+    assert info.dense_index.similarity_function == "COSINE"
+    assert info.dense_index.embedding_model == ""
+
+    assert info.sparse_index is not None
+    assert info.sparse_index.embedding_model == ""

--- a/upstash_vector/types.py
+++ b/upstash_vector/types.py
@@ -132,12 +132,46 @@ class NamespaceInfo:
 
 
 @dataclass
+class DenseIndexInfo:
+    dimension: int
+    similarity_function: str
+    embedding_model: str
+
+    @classmethod
+    def _from_json(cls, obj: Optional[dict]) -> Optional["DenseIndexInfo"]:
+        if not obj:
+            return None
+
+        return cls(
+            dimension=obj["dimension"],
+            similarity_function=obj["similarityFunction"],
+            embedding_model=obj["embeddingModel"],
+        )
+
+
+@dataclass
+class SparseIndexInfo:
+    embedding_model: str
+
+    @classmethod
+    def _from_json(cls, obj: Optional[dict]) -> Optional["SparseIndexInfo"]:
+        if not obj:
+            return None
+
+        return cls(
+            embedding_model=obj["embeddingModel"],
+        )
+
+
+@dataclass
 class InfoResult:
     vector_count: int
     pending_vector_count: int
     index_size: int
     dimension: int
     similarity_function: str
+    dense_index: Optional[DenseIndexInfo]
+    sparse_index: Optional[SparseIndexInfo]
     namespaces: Dict[str, NamespaceInfo]
 
     @classmethod
@@ -148,6 +182,8 @@ class InfoResult:
             index_size=obj["indexSize"],
             dimension=obj["dimension"],
             similarity_function=obj["similarityFunction"],
+            dense_index=DenseIndexInfo._from_json(obj.get("denseIndex")),
+            sparse_index=SparseIndexInfo._from_json(obj.get("sparseIndex")),
             namespaces={
                 ns: NamespaceInfo._from_json(ns_info)
                 for ns, ns_info in obj["namespaces"].items()


### PR DESCRIPTION
We wanted to add embedding model info to the info endpoint, as well as having some separate fields for dense and sparse indexes.

For now, there is some duplicate information in the top level fields and the fields in the dense_index, but we might deprecate the top level fields later on.