### PR TITLE
Allow upserting data as vector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "upstash-vector"
-version = "0.7.0"
+version = "0.7.1"
 description = "Serverless Vector SDK from Upstash"
 license = "MIT"
 authors = ["Upstash <support@upstash.com>"]

--- a/tests/core/test_upsert.py
+++ b/tests/core/test_upsert.py
@@ -1077,3 +1077,44 @@ async def test_upsert_hybrid_async(async_hybrid_index: AsyncIndex, ns: str):
         assert r.vector is not None
         assert len(r.vector) == 2
         assert r.sparse_vector is not None
+
+
+@pytest.mark.parametrize("ns", NAMESPACES)
+def test_upsert_data_as_vector(embedding_index: Index, ns: str):
+    embedding_index.upsert(
+        vectors=[
+            Vector(id="test", data="data"),
+        ],
+        namespace=ns,
+    )
+
+    res = embedding_index.fetch(
+        ids=["test"],
+        include_data=True,
+        namespace=ns,
+    )
+
+    assert res[0] is not None
+    assert res[0].id == "test"
+    assert res[0].data == "data"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ns", NAMESPACES)
+async def test_upsert_data_as_vector_async(async_embedding_index: AsyncIndex, ns: str):
+    await async_embedding_index.upsert(
+        vectors=[
+            Vector(id="test", data="data"),
+        ],
+        namespace=ns,
+    )
+
+    res = await async_embedding_index.fetch(
+        ids=["test"],
+        include_data=True,
+        namespace=ns,
+    )
+
+    assert res[0] is not None
+    assert res[0].id == "test"
+    assert res[0].data == "data"

--- a/upstash_vector/__init__.py
+++ b/upstash_vector/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 from upstash_vector.client import AsyncIndex, Index
 from upstash_vector.types import Vector

--- a/upstash_vector/utils.py
+++ b/upstash_vector/utils.py
@@ -19,13 +19,24 @@ def sequence_to_vectors(
 
 def _parse_vector(vector: Union[dict, tuple, Vector, Data]) -> Union[Vector, Data]:
     if isinstance(vector, Vector):
+        maybe_data = True
+
         dense = vector.vector
         if dense is not None:
+            maybe_data = False
             vector.vector = to_list(dense)
 
         sparse = vector.sparse_vector
         if sparse is not None:
+            maybe_data = False
             vector.sparse_vector = to_sparse_vector(sparse)
+
+        if maybe_data and vector.data:
+            return Data(
+                id=vector.id,
+                data=vector.data,
+                metadata=vector.metadata,
+            )
 
         return vector
     elif isinstance(vector, Data):


### PR DESCRIPTION
I stumbled upon this problem while using the sample code provided in the console. If the index is created with an embedding model, we still try to use `Vector` type with only data field. It should have been `Data`, but I think this is a mistake that can happen a lot. So, we now allow such usages. If this is wrong, server will reject it anyway, just like it does.