### PR TITLE
Allow users to opt out for telemetry

### DIFF
--- a/upstash_vector/client.py
+++ b/upstash_vector/client.py
@@ -30,7 +30,12 @@ class Index(IndexOperations):
     """
 
     def __init__(
-        self, url: str, token: str, retries: int = 3, retry_interval: float = 1.0
+        self,
+        url: str,
+        token: str,
+        retries: int = 3,
+        retry_interval: float = 1.0,
+        allow_telemetry: bool = True,
     ):
         self._url = url
         self._client = httpx.Client(
@@ -41,7 +46,7 @@ class Index(IndexOperations):
         )
         self._retries = retries
         self._retry_interval = retry_interval
-        self._headers = generate_headers(token)
+        self._headers = generate_headers(token, allow_telemetry)
 
     def _execute_request(self, payload: Any = "", path: str = ""):
         url_with_path = f"{self._url}{path}"
@@ -55,7 +60,12 @@ class Index(IndexOperations):
         )
 
     @classmethod
-    def from_env(cls, retries: int = 3, retry_interval: float = 1.0) -> "Index":
+    def from_env(
+        cls,
+        retries: int = 3,
+        retry_interval: float = 1.0,
+        allow_telemetry: bool = True,
+    ) -> "Index":
         """
         Load the credentials from environment, and returns a client.
         """
@@ -65,6 +75,7 @@ class Index(IndexOperations):
             environ["UPSTASH_VECTOR_REST_TOKEN"],
             retries,
             retry_interval,
+            allow_telemetry,
         )
 
 
@@ -92,9 +103,9 @@ class AsyncIndex(AsyncIndexOperations):
         token: str,
         retries: int = 3,
         retry_interval: float = 1.0,
+        allow_telemetry: bool = True,
     ):
         self._url = url
-        self._headers = generate_headers(token)
         self._client = httpx.AsyncClient(
             timeout=httpx.Timeout(
                 timeout=600.0,
@@ -103,6 +114,7 @@ class AsyncIndex(AsyncIndexOperations):
         )
         self._retries = retries
         self._retry_interval = retry_interval
+        self._headers = generate_headers(token, allow_telemetry)
 
     async def _execute_request_async(self, payload: Any = "", path: str = ""):
         url_with_path = f"{self._url}{path}"
@@ -116,7 +128,12 @@ class AsyncIndex(AsyncIndexOperations):
         )
 
     @classmethod
-    def from_env(cls, retries: int = 3, retry_interval: float = 1.0) -> "AsyncIndex":
+    def from_env(
+        cls,
+        retries: int = 3,
+        retry_interval: float = 1.0,
+        allow_telemetry: bool = True,
+    ) -> "AsyncIndex":
         """
         Load the credentials from environment, and returns a client.
         """
@@ -126,4 +143,5 @@ class AsyncIndex(AsyncIndexOperations):
             environ["UPSTASH_VECTOR_REST_TOKEN"],
             retries,
             retry_interval,
+            allow_telemetry,
         )

--- a/upstash_vector/http.py
+++ b/upstash_vector/http.py
@@ -10,21 +10,23 @@ from upstash_vector import __version__
 from upstash_vector.errors import UpstashError
 
 
-def generate_headers(token) -> Dict[str, str]:
+def generate_headers(token: str, allow_telemetry: bool) -> Dict[str, str]:
     headers = {
         "Authorization": f"Bearer {token}",
-        "Upstash-Telemetry-Sdk": f"upstash-vector-py@v{__version__}",
-        "Upstash-Telemetry-Runtime": f"python@v{python_version()}",
     }
 
-    if os.getenv("VERCEL"):
-        platform = "vercel"
-    elif os.getenv("AWS_REGION"):
-        platform = "aws"
-    else:
-        platform = "unknown"
+    if allow_telemetry:
+        headers["Upstash-Telemetry-Sdk"] = f"upstash-vector-py@v{__version__}"
+        headers["Upstash-Telemetry-Runtime"] = f"python@v{python_version()}"
 
-    headers["Upstash-Telemetry-Platform"] = platform
+        if os.getenv("VERCEL"):
+            platform = "vercel"
+        elif os.getenv("AWS_REGION"):
+            platform = "aws"
+        else:
+            platform = "unknown"
+
+        headers["Upstash-Telemetry-Platform"] = platform
 
     return headers
 


### PR DESCRIPTION
We were always sending the telemetry headers but not collecting it in the server. We now started collecting it, so we should give users a way to opt out of it.