### PR TITLE
DX-1794: Do not make further requests for resumable query for non-existing namespaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "upstash-vector"
-version = "0.8.0"
+version = "0.8.1"
 description = "Serverless Vector SDK from Upstash"
 license = "MIT"
 authors = ["Upstash <support@upstash.com>"]

--- a/tests/core/test_resumable_query.py
+++ b/tests/core/test_resumable_query.py
@@ -451,3 +451,28 @@ async def test_resumable_query_hybrid_embedding_index_query_mode_async(
             assert next_result[0].id == "id1"
 
     await assert_eventually_async(assertion)
+
+
+def test_resumable_query_non_existing_namespace(index: Index):
+    result, handle = index.resumable_query(
+        vector=[0.1, 0.2],
+        namespace="non-existing-namespace",
+    )
+
+    with handle:
+        assert len(result) == 0
+        next_result = handle.fetch_next(5)
+        assert len(next_result) == 0
+
+
+@pytest.mark.asyncio
+async def test_resumable_query_non_existing_namespace_async(async_index: AsyncIndex):
+    result, handle = await async_index.resumable_query(
+        vector=[0.1, 0.2],
+        namespace="non-existing-namespace",
+    )
+
+    async with handle:
+        assert len(result) == 0
+        next_result = await handle.fetch_next(5)
+        assert len(next_result) == 0

--- a/upstash_vector/core/index_operations.py
+++ b/upstash_vector/core/index_operations.py
@@ -1295,6 +1295,9 @@ class ResumableQueryHandle:
         Returns:
             List[QueryResult]: The next batch of query results.
         """
+        if self._uid == "":
+            return []
+
         payload = {"uuid": self._uid, "additionalK": additional_k}
         result = self._exec_fn(payload, RESUMABLE_QUERY_NEXT_PATH)
         return [QueryResult._from_json(obj) for obj in result]
@@ -1303,6 +1306,9 @@ class ResumableQueryHandle:
         """
         Stops the resumable query.
         """
+        if self._uid == "":
+            return
+
         payload = {"uuid": self._uid}
         self._exec_fn(payload, RESUMABLE_QUERY_END_PATH)
 
@@ -1338,6 +1344,9 @@ class AsyncResumableQueryHandle:
         Returns:
             List[QueryResult]: The next batch of query results.
         """
+        if self._uid == "":
+            return []
+
         payload = {"uuid": self._uid, "additionalK": additional_k}
         result = await self._exec_fn(payload, RESUMABLE_QUERY_NEXT_PATH)
         return [QueryResult._from_json(obj) for obj in result]
@@ -1346,5 +1355,8 @@ class AsyncResumableQueryHandle:
         """
         Stops the resumable query.
         """
+        if self._uid == "":
+            return
+
         payload = {"uuid": self._uid}
         await self._exec_fn(payload, RESUMABLE_QUERY_END_PATH)


### PR DESCRIPTION
When the server sends an empty uuid as response to the resumable query start, for example when no such namespace exists, we should not make further fetch next or stop calls, as no resumable query has started.